### PR TITLE
Various fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
-configurations/agent/.gradle
+/.vagrant/
+/.sources/
+.gradle/

--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ Install VirtualBox from [https://www.virtualbox.org](https://www.virtualbox.org)
 
 Please follow the [Vagrant installation guide](https://www.vagrantup.com/docs/installation/).
 
-## Vagrant Host Updater
+## Vagrant Host Manager
 
-Vagrant::Hostupdater can be found [here](vagrant host updater). Install hostupdater using following command:
+Vagrant::Hostmanager can be found [here](https://github.com/devopsgroup-io/vagrant-hostmanager). Install hostupdater using following command:
 
 ```
-$ vagrant plugin install vagrant-hostsupdater
+$ vagrant plugin install vagrant-hostmanager
 ```
 
 ## vagrant-vbguest plugin

--- a/configurations/nginx/sites-available/is.conf
+++ b/configurations/nginx/sites-available/is.conf
@@ -2,7 +2,7 @@ server {
     listen 443;
     listen [::]:443;
     ssl on;
-    server_name devenv-auth;
+    server_name devenv-auth devenv-is;
 
     ssl_password_file    /etc/nginx/certs/global.pass;
     ssl_certificate      /etc/nginx/certs/services/devenv-is.cert.pem;

--- a/configurations/nginx/sites-available/regex-notls.conf
+++ b/configurations/nginx/sites-available/regex-notls.conf
@@ -8,7 +8,7 @@ server {
     ssl_certificate_key  /etc/nginx/certs/services/devenv-regex.key.pem;
 
     location / {
-      proxy_pass https://localhost:9443/ExtensionAPI-1.4.0-SNAPSHOT/services/;
+      proxy_pass https://localhost:9443/ExtensionAPI/;
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/configurations/nginx/sites-available/regex.conf
+++ b/configurations/nginx/sites-available/regex.conf
@@ -12,7 +12,7 @@ server {
     ssl_verify_depth 1;
 
     location / {
-      proxy_pass http://localhost:9443/ExtensionAPI-1.4.0-SNAPSHOT/services;
+      proxy_pass http://localhost:9443/ExtensionAPI/;
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/configurations/regex/build.gradle
+++ b/configurations/regex/build.gradle
@@ -20,4 +20,5 @@ dependencies {
 task copyWar(type: Copy) {
   from configurations.regex
   into "/usr/share/wso2is/repository/deployment/server/webapps"
+  rename '(.+?)-(.+(-SNAPSHOT)?)\\.war', '$1.war'
 }


### PR DESCRIPTION
- fix for missing server_name definition for devenv-is
- fix for incorrect proxying for RegExt in nginx
- changed RegExt WAR file name so that API endpoint is always the same,
regardless of version
- fix for non-functioning networking when using static private IP
- switched the /etc/hosts manager plugin to vagrant-hostmanager which
can deal with DHCP-assigned IPs
- updated README